### PR TITLE
Update links in CONTRIBUTING.md Move the links outside of the code blocks so that GitHub markdown will process them for us.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ working on the [Hugo](https://discuss.gohugo.io/t/hugo-development-how-to-contri
 project use it:
 
 ```
-# install [hub](https://hub.github.com/) with alias to git
+# install hub with alias to git (seriously)
 # clone the repository
 $ go get -u -v github.com/quoha/quoha
 $ cd $GOPATH/src/github.com/quoha/quoha/
@@ -31,8 +31,8 @@ $ go test ./...
 # confirm unit test passess
 $ go test ./...
 # always format the code before committing
-$ gofmt
-# add a nice commit [message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+$ go fmt main.go
+# add a nice commit message
 $ git commit
 # then use hub to fork and push the changes
 $ git fork
@@ -43,5 +43,6 @@ $ git pull-request
 Other references
 ----------------
 
-Try "[Contributing to Open Source Git Repositories in Go](https://splice.com/blog/contributing-open-source-git-repositories-go/)
-for an explanation.
+1. Try "[Contributing to Open Source Git Repositories in Go](https://splice.com/blog/contributing-open-source-git-repositories-go/)" for an explanation.
+2. Visit [hub](https://hub.github.com/) to install the hub application. Be sure to alias to git.
+3. See [Pope](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), the standard.

--- a/main.go
+++ b/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println("Hello, Lexer Luth!")
+	fmt.Println("Hello, Lexer Luth!")
 }


### PR DESCRIPTION
Resolves: #8